### PR TITLE
Add/rename all cars to match iRacing's current state (2020S1)

### DIFF
--- a/vehicles.ini
+++ b/vehicles.ini
@@ -1,81 +1,98 @@
 ;name,alias,gears,rpm
 ;will be sorted alphabetically by alias
 astonmartin dbr9,Aston Martin DBR9 GT1,6,7000
+audi90gto,Audi 90 GTO,5,7600
+audir18,Audi R18,6,4200
 audir8gt3,Audi R8 LMS,6,7000
-audir18,Audi R18,6,4200 
 audirs3lms,Audi RS 3 LMS,6,6600
 bmwm8gte,BMW M8 GTE,6,6800
 bmwz4gt3,BMW Z4 GT3,6,8400
-c6r,Chevrolet Corvette C6R GT1,6,5700
-c7vettedp,Chevrolet Corvette C7 Daytona Prototype,6,6800
 cadillacctsvr,Cadillac CTS-V Racecar,6,7400
-dallara,Dallara IndyCar,6,10000
+c6r,Chevrolet Corvette C6.R GT1,6,5700
+c7vettedp,Chevrolet Corvette C7 Daytona Prototype,6,6800
+latemodel,Chevrolet Monte Carlo SS,4,6000
 dallaradw12,Dallara DW12,6,11700
 dallaraf3,Dallara F3,6,7000
-dallarair18,Dallara IR18,6,11700 
+dallarair18,Dallara IR18,6,11700
+dirtlatemodel 350,Dirt Late Model - Limited,1,7400
+dirtlatemodel 358,Dirt Late Model - Pro,1,7400
+dirtlatemodel 438,Dirt Late Model - Super,1,7400
+legends dirtford34c,Dirt Legends Ford '34 Coupe,5,10300
+dirtmidget,Dirt Midget,1,10300
+dirtsprint winged 305,Dirt Sprint Car - 305,1,8900
+dirtsprint winged 360,Dirt Sprint Car - 360,1,8900
+dirtsprint nonwinged 360,Dirt Sprint Car - 360 Non-Winged,1,8900
+dirtsprint winged 410,Dirt Sprint Car - 410,1,8900
+dirtsprint nonwinged 410,Dirt Sprint Car - 410 Non-Winged,1,8900
 ferrari488gt3,Ferrari 488 GT3,6,7000
 ferrari488gte,Ferrari 488 GTE,6,6500
-fordfiestarswrc,Ford Fiesta RS WRC,6,7800 
-fordgt gt3,Ford GT GT3,6,6800
+fordfiestarswrc,Ford Fiesta RS WRC,6,7800
 fordgt,Ford GT,6,6800
-fordgt2017,Ford GTE,6,7200
-fordv8sc,Ford Falcon FG01 V8,6,7300
-formulamazda,Star Mazda,6,8300
+fordgt2017,Ford GT - 2017,6,7200
+fordgt gt3,Ford GT GT3,6,6800
+fr500s,Ford Mustang FR500S,6,6600
 formularenault20,Formula Renault 2.0,7,7200
 formularenault35,Formula Renault 3.5,6,9000
-fr500s,Ford Mustang FR500S,6,6600
+mx5 mx52016,Global Mazda MX-5 Cup,6,6400
 hpdarx01c,HPD ARX-01c,6,9500
-jettatdi,VW Jetta TDI Cup,6,4500
-kiaoptima,KIA Optima,6,7000
-latemodel,Chevrolet Monte Carlo SS,4,6000
-legends ford34c rookie,Legends Ford '34 Coupe Rookie,5,10000
+dallara,Indycar Dallara - 2011,6,10000
+kiaoptima,Kia Optima,6,7000
 legends ford34c,Legends Ford '34 Coupe,5,10000
+legends ford34c rookie,Legends Ford '34 Coupe - Rookie,5,10000
 lotus49,Lotus 49,5,9000
 lotus79,Lotus 79,5,10600
+protrucks pro2lite,Lucas Oil Off Road Pro 2 Lite,3,6800
+protrucks pro2truck,Lucas Oil Off Road Pro 2 Truck,3,6800
+protrucks pro4truck,Lucas Oil Off Road Pro 4 Truck,6,6800
 mclarenmp4,McLaren MP4-12C GT3,6,7000
 mclarenmp430,McLaren MP4-30,8,11300
 mercedesamggt3,Mercedes AMG GT3,6,6800
-mx5 cup,Mazda MX-5 Cup,6,6800
-mx5 mx52016,Mazda MX-5 Global Cup,6,6400
-mx5 roadster,Mazda MX-5 Roadster,5,6800
+skmodified tour,Modified - NASCAR Whelen Tour,4,10000
+skmodified,Modified - SK,4,10000
+trucks silverado2015,NASCAR Gander Outdoors Chevrolet Silverado,4,8000
+trucks tundra2015,NASCAR Gander Outdoors Toyota Tundra,4,8000
+stockcars2 chevy,NASCAR K&N Pro Chevrolet Impala,4,8000
+stockcars camarozl12018,NASCAR Monster Energy Cup Chevrolet Camaro ZL1,4,9000
+stockcars fordmustang2019,NASCAR Monster Energy Cup Ford Mustang,4,9000
+stockcars toyotacamry,NASCAR Monster Energy Cup Toyota Camry,4,9000
+trucks silverado,NASCAR Truck Series Chevrolet Silverado - 2013,4,8000
+stockcars2 camaro2019,NASCAR XFINITY Chevrolet Camaro,4,8300
+stockcars2 mustang2019,NASCAR XFINITY Ford Mustang,4,8300
+stockcars2 supra2019,NASCAR XFINITY Toyota Supra,4,8300
 nissangtpzxt,Nissan GTP ZX-T,5,7400
-porsche911cup,Porsche 911 GT3 Cup,6,8200
-porsche919,Porsche 919,7,8600 
-porsche991rsr,Porsche 911 RSR,6,9300 
-protrucks pro2truck,Lucas Oil Off Road Pro 2 Truck,3,6800 
-protrucks pro4truck,Lucas Oil Off Road Pro 4 Truck,6,6800
-radical sr8,Radical SR8,6,10400
-rileydp,Riley MkXX Daytona Prototype,5,7000
-rt2000,Skip Barber Formula 2000,5,6000
-rufrt12r awd,Ruf RT 12R AWD,6,7000
-rufrt12r rwd,Ruf RT 12R RWD,6,6600
-rufrt12r track cspec,Ruf RT 12R C-Spec,6,7800
-rufrt12r track,Ruf RT 12R Track,6,8800
-silvercrown,Silver Crown,2,10000
-skmodified tour,NASCAR Whelen Tour Modified,4,10000
-skmodified,NASCAR Whelen SK Modified,4,10000
-solstice rookie,Pontiac Solstice Rookie,5,7000
 solstice,Pontiac Solstice,5,7000
+solstice rookie,Pontiac Solstice - Rookie,5,7000
+porsche911cup,Porsche 911 GT3 Cup (991),6,8200
+porsche991rsr,Porsche 911 RSR,6,9300
+porsche919,Porsche 919,7,8600
+formulamazda,Pro Mazda,6,8300
+radical sr8,Radical SR8,6,10400
+rufrt12r awd,Ruf RT 12R AWD,6,7000
+rufrt12r track cspec,Ruf RT 12R C-Spec,6,7800
+rufrt12r rwd,Ruf RT 12R RWD,6,6600
+rufrt12r track,Ruf RT 12R Track,6,8800
 specracer,SCCA Spec Racer Ford,5,5700
+silvercrown,Silver Crown,2,10000
+rt2000,Skip Barber Formula 2000,5,6000
 sprint,Sprint Car,1,10000
-stockcars chevyss,NASCAR Sprint Cup Chevrolet SS,4,8000
-stockcars fordfusion,NASCAR Sprint Cup Ford Fusion,4,8000
-stockcars impala,NASCAR K&N Pro Chevrolet Impala,4,8000
-stockcars toyotacamry,NASCAR Sprint Cup Toyota Camry,4,8000
-stockcars2 camry2015,NASCAR XFINITY Toyota Camry,4,8000
-stockcars2 chevy cot,Chevrolet Impala-COT,4,8000
-stockcars2 chevy,Chevrolet Impala Old Class B,4,8000
-stockcars2 nwcamaro2014,NASCAR XFINITY Chevrolet Camaro,4,8000
-stockcars2 nwford2013,NASCAR XFINITY Ford Mustang,4,8000
 streetstock,Street Stock,4,6000
 subaruwrxsti,Subaru WRX STI,6,5800
+v8supercars fordmustanggt,Supercars Ford Mustang GT,6,7450
+v8supercars holden2019,Supercars Holden ZB Commodore,6,7450
 superlatemodel,Super Late Model,4,6000
-trucks silverado,Chevrolet Silverado,4,8000
-trucks silverado2015,NASCAR Camping World Chevy Silverado,4,8000
-trucks tundra2015,NASCAR Camping World Toyota Tundra,4,8000
-v8supercars ford2014,Ford Falcon FG V8 Supercar,6,7200
-v8supercars holden2014,Holden Commodore VF V8,6,7100
-v8supercars ford2019,Supercars Ford Mustang GT,6,7100
-v8supercars holden2019,Supercars Holden ZB Commodore,6,7100
-vwbeetlegrc,Volkswagen Beetle GRC,6,7800 
+vwbeetlegrc,VW Beetle,6,7800
+jettatdi,VW Jetta TDI Cup,6,4500
 williamsfw31,Williams-Toyota FW31,7,17600
+mx5 cup,[Archive] Mazda MX-5 Cup - 2015,6,6800
+mx5 roadster,[Archive] Mazda MX-5 Roadster - 2015,5,6800
+stockcars2 chevy cot,[Archive] Nationwide Chevrolet Impala - 2011,4,8000
+rileydp,[Archive] Riley MkXX Daytona Prototype,5,7000
+stockcars impala,[Archive] Sprint Cup Chevrolet Impala COT - 2011,4,8000
+stockcars chevyss,[Archive] Sprint Cup Chevrolet SS,4,8000
+stockcars fordfusion,[Archive] Sprint Cup Ford Fusion,4,8000
+fordv8sc,[Archive] V8 Supercar Ford Falcon - 2012,6,7300
+v8supercars ford2014,[Archive] V8 Supercars Ford FG Falcon,6,7450
+v8supercars holden2014,[Archive] V8 Supercars Holden VF Commodore,6,7450
+stockcars2 nwcamaro2014,[Archive] XFINITY Chevrolet Camaro,4,8000
+stockcars2 nwford2013,[Archive] XFINITY Ford Mustang,4,8000
+stockcars2 camry2015,[Archive] XFINITY Toyota Camry,4,8000


### PR DESCRIPTION
Add all missing cars, rename existing cars to match current iRacing names, sort names in file to match iRacing order. All missing car values are pulled from the iRacing API.

Note that the sort order is not the one used in SoundShift; this is because the sorting algorithm used in the original SoundShift code does not correctly sort non-alphabetical characters. It is possible to modify the executable yourself to change the sort option. There is information on this in a branch of my fork; however, it's not for the faint-hearted, and is only really a usability tweak.