### PR TITLE
Minor NASCAR Cup branding update

### DIFF
--- a/vehicles.ini
+++ b/vehicles.ini
@@ -52,9 +52,9 @@ skmodified,Modified - SK,4,10000
 trucks silverado2015,NASCAR Gander Outdoors Chevrolet Silverado,4,8000
 trucks tundra2015,NASCAR Gander Outdoors Toyota Tundra,4,8000
 stockcars2 chevy,NASCAR K&N Pro Chevrolet Impala,4,8000
-stockcars camarozl12018,NASCAR Monster Energy Cup Chevrolet Camaro ZL1,4,9000
-stockcars fordmustang2019,NASCAR Monster Energy Cup Ford Mustang,4,9000
-stockcars toyotacamry,NASCAR Monster Energy Cup Toyota Camry,4,9000
+stockcars camarozl12018,NASCAR Cup Chevrolet Camaro ZL1,4,9000
+stockcars fordmustang2019,NASCAR Cup Ford Mustang,4,9000
+stockcars toyotacamry,NASCAR Cup Toyota Camry,4,9000
 trucks silverado,NASCAR Truck Series Chevrolet Silverado - 2013,4,8000
 stockcars2 camaro2019,NASCAR XFINITY Chevrolet Camaro,4,8300
 stockcars2 mustang2019,NASCAR XFINITY Ford Mustang,4,8300


### PR DESCRIPTION
To match the changes made in 2020 Season 1 Patch 3 Hotfix 1. Removed "Monster Energy" from the titles of the NASCAR Cup cars.