### PR TITLE
feat(vehicles): update list to comply with new iRacing naming scheme 2020S2P2

### DIFF
--- a/vehicles.ini
+++ b/vehicles.ini
@@ -1,5 +1,5 @@
 ;name,alias,gears,rpm
-;will be sorted alphabetically by alias
+;will be sorted alphabetically by alias,,,
 astonmartin dbr9,Aston Martin DBR9 GT1,6,7000
 audi90gto,Audi 90 GTO,5,7600
 audir18,Audi R18,6,4200
@@ -35,7 +35,6 @@ formularenault20,Formula Renault 2.0,7,7200
 formularenault35,Formula Renault 3.5,6,9000
 mx5 mx52016,Global Mazda MX-5 Cup,6,6400
 hpdarx01c,HPD ARX-01c,6,9500
-dallara,[Legacy] Indycar Dallara - 2009,6,10000
 kiaoptima,Kia Optima,6,7000
 legends ford34c,Legends Ford '34 Coupe,5,10000
 legends ford34c rookie,Legends Ford '34 Coupe - Rookie,5,10000
@@ -49,13 +48,12 @@ mclarenmp430,McLaren MP4-30,8,11300
 mercedesamggt3,Mercedes AMG GT3,6,6800
 skmodified tour,Modified - NASCAR Whelen Tour,4,10000
 skmodified,Modified - SK,4,10000
-trucks silverado2015,NASCAR Gander Outdoors Chevrolet Silverado,4,8000
-trucks tundra2015,NASCAR Gander Outdoors Toyota Tundra,4,8000
-stockcars2 chevy,NASCAR K&N Pro Chevrolet Impala,4,8000
 stockcars camarozl12018,NASCAR Cup Chevrolet Camaro ZL1,4,9000
 stockcars fordmustang2019,NASCAR Cup Ford Mustang,4,9000
 stockcars toyotacamry,NASCAR Cup Toyota Camry,4,9000
-trucks silverado,[Legacy] NASCAR Truck Chevrolet Silverado - 2008,4,8000
+trucks silverado2015,NASCAR Gander Outdoors Chevrolet Silverado,4,8000
+trucks tundra2015,NASCAR Gander Outdoors Toyota Tundra,4,8000
+stockcars2 chevy,NASCAR K&N Pro Chevrolet Impala,4,8000
 stockcars2 camaro2019,NASCAR XFINITY Chevrolet Camaro,4,8300
 stockcars2 mustang2019,NASCAR XFINITY Ford Mustang,4,8300
 stockcars2 supra2019,NASCAR XFINITY Toyota Supra,4,8300
@@ -78,22 +76,24 @@ rt2000,Skip Barber Formula 2000,5,6000
 sprint,Sprint Car,1,10000
 streetstock,Street Stock,4,6000
 subaruwrxsti,Subaru WRX STI,6,5800
+superlatemodel,Super Late Model,4,6000
 v8supercars fordmustanggt,Supercars Ford Mustang GT,6,7450
 v8supercars holden2019,Supercars Holden ZB Commodore,6,7450
-superlatemodel,Super Late Model,4,6000
 vwbeetlegrc,VW Beetle,6,7800
 jettatdi,VW Jetta TDI Cup,6,4500
 williamsfw31,Williams-Toyota FW31,7,17600
+dallara,[Legacy] Indycar Dallara - 2009,6,10000
 mx5 cup,[Legacy] Mazda MX-5 Cup - 2010,6,6800
 mx5 roadster,[Legacy] Mazda MX-5 Roadster - 2010,5,6800
-stockcars2 chevy cot,[Legacy] NASCAR Nationwide Chevrolet Impala - 2012,4,8000
-rileydp,[Legacy] Riley MkXX Daytona Prototype - 2008,5,7000
 stockcars impala,[Legacy] NASCAR Cup Chevrolet Impala COT - 2009,4,8000
 stockcars chevyss,[Legacy] NASCAR Cup Chevrolet SS - 2013,4,8000
 stockcars fordfusion,[Legacy] NASCAR Cup Ford Fusion - 2016,4,8000
-fordv8sc,[Legacy] V8 Supercar Ford Falcon - 2009,6,7300
-v8supercars ford2014,[Legacy] V8 Supercar Ford FG Falcon - 2014,6,7450
-v8supercars holden2014,[Legacy] V8 Supercar Holden VF Commodore - 2014,6,7450
+stockcars2 chevy cot,[Legacy] NASCAR Nationwide Chevrolet Impala - 2012,4,8000
+trucks silverado,[Legacy] NASCAR Truck Chevrolet Silverado - 2008,4,8000
 stockcars2 nwcamaro2014,[Legacy] NASCAR Xfinity Chevrolet Camaro - 2014,4,8000
 stockcars2 nwford2013,[Legacy] NASCAR Xfinity Ford Mustang - 2016,4,8000
 stockcars2 camry2015,[Legacy] NASCAR Xfinity Toyota Camry - 2015,4,8000
+rileydp,[Legacy] Riley MkXX Daytona Prototype - 2008,5,7000
+fordv8sc,[Legacy] V8 Supercar Ford Falcon - 2009,6,7300
+v8supercars ford2014,[Legacy] V8 Supercar Ford FG Falcon - 2014,6,7450
+v8supercars holden2014,[Legacy] V8 Supercar Holden VF Commodore - 2014,6,7450

--- a/vehicles.ini
+++ b/vehicles.ini
@@ -1,5 +1,4 @@
-;name,alias,gears,rpm
-;will be sorted alphabetically by alias,,,
+;name,alias,gears,rpm (will be sorted alphabetically by alias)
 astonmartin dbr9,Aston Martin DBR9 GT1,6,7000
 audi90gto,Audi 90 GTO,5,7600
 audir18,Audi R18,6,4200

--- a/vehicles.ini
+++ b/vehicles.ini
@@ -35,7 +35,7 @@ formularenault20,Formula Renault 2.0,7,7200
 formularenault35,Formula Renault 3.5,6,9000
 mx5 mx52016,Global Mazda MX-5 Cup,6,6400
 hpdarx01c,HPD ARX-01c,6,9500
-dallara,Indycar Dallara - 2011,6,10000
+dallara,[Legacy] Indycar Dallara - 2009,6,10000
 kiaoptima,Kia Optima,6,7000
 legends ford34c,Legends Ford '34 Coupe,5,10000
 legends ford34c rookie,Legends Ford '34 Coupe - Rookie,5,10000
@@ -55,7 +55,7 @@ stockcars2 chevy,NASCAR K&N Pro Chevrolet Impala,4,8000
 stockcars camarozl12018,NASCAR Cup Chevrolet Camaro ZL1,4,9000
 stockcars fordmustang2019,NASCAR Cup Ford Mustang,4,9000
 stockcars toyotacamry,NASCAR Cup Toyota Camry,4,9000
-trucks silverado,NASCAR Truck Series Chevrolet Silverado - 2013,4,8000
+trucks silverado,[Legacy] NASCAR Truck Chevrolet Silverado - 2008,4,8000
 stockcars2 camaro2019,NASCAR XFINITY Chevrolet Camaro,4,8300
 stockcars2 mustang2019,NASCAR XFINITY Ford Mustang,4,8300
 stockcars2 supra2019,NASCAR XFINITY Toyota Supra,4,8300
@@ -84,16 +84,16 @@ superlatemodel,Super Late Model,4,6000
 vwbeetlegrc,VW Beetle,6,7800
 jettatdi,VW Jetta TDI Cup,6,4500
 williamsfw31,Williams-Toyota FW31,7,17600
-mx5 cup,[Archive] Mazda MX-5 Cup - 2015,6,6800
-mx5 roadster,[Archive] Mazda MX-5 Roadster - 2015,5,6800
-stockcars2 chevy cot,[Archive] Nationwide Chevrolet Impala - 2011,4,8000
-rileydp,[Archive] Riley MkXX Daytona Prototype,5,7000
-stockcars impala,[Archive] Sprint Cup Chevrolet Impala COT - 2011,4,8000
-stockcars chevyss,[Archive] Sprint Cup Chevrolet SS,4,8000
-stockcars fordfusion,[Archive] Sprint Cup Ford Fusion,4,8000
-fordv8sc,[Archive] V8 Supercar Ford Falcon - 2012,6,7300
-v8supercars ford2014,[Archive] V8 Supercars Ford FG Falcon,6,7450
-v8supercars holden2014,[Archive] V8 Supercars Holden VF Commodore,6,7450
-stockcars2 nwcamaro2014,[Archive] XFINITY Chevrolet Camaro,4,8000
-stockcars2 nwford2013,[Archive] XFINITY Ford Mustang,4,8000
-stockcars2 camry2015,[Archive] XFINITY Toyota Camry,4,8000
+mx5 cup,[Legacy] Mazda MX-5 Cup - 2010,6,6800
+mx5 roadster,[Legacy] Mazda MX-5 Roadster - 2010,5,6800
+stockcars2 chevy cot,[Legacy] NASCAR Nationwide Chevrolet Impala - 2012,4,8000
+rileydp,[Legacy] Riley MkXX Daytona Prototype - 2008,5,7000
+stockcars impala,[Legacy] NASCAR Cup Chevrolet Impala COT - 2009,4,8000
+stockcars chevyss,[Legacy] NASCAR Cup Chevrolet SS - 2013,4,8000
+stockcars fordfusion,[Legacy] NASCAR Cup Ford Fusion - 2016,4,8000
+fordv8sc,[Legacy] V8 Supercar Ford Falcon - 2009,6,7300
+v8supercars ford2014,[Legacy] V8 Supercar Ford FG Falcon - 2014,6,7450
+v8supercars holden2014,[Legacy] V8 Supercar Holden VF Commodore - 2014,6,7450
+stockcars2 nwcamaro2014,[Legacy] NASCAR Xfinity Chevrolet Camaro - 2014,4,8000
+stockcars2 nwford2013,[Legacy] NASCAR Xfinity Ford Mustang - 2016,4,8000
+stockcars2 camry2015,[Legacy] NASCAR Xfinity Toyota Camry - 2015,4,8000


### PR DESCRIPTION
Closes #13 

From [2020 Season 2 Patch 2 - Release Notes [2020.03.26.01]](https://members.iracing.com/jforum/posts/list/3703250.page).

Cars and Tracks
A variety of cars and tracks have had their names changed to better reflect their current status within the world of iRacing Official Series. These changes include re-branding the prefix term "[Archive]" to "[Legacy]", and changing all appended dates to best reflect the year in which the car or track data represents. These changes include the following:

CARS:
- [Legacy] Indycar Dallara - 2009, formerly known as, Indycar Dallara - 2011
- [Legacy] Mazda MX-5 Cup - 2010, formerly known as, [Archive] Mazda MX-5 Cup - 2015
- [Legacy] Mazda MX-5 Roadster - 2010, formerly known as, [Archive] Mazda MX-5 Roadster - 2015
- [Legacy] NASCAR Cup Chevrolet Impala COT - 2009, formerly known as, [Archive] Sprint Cup Chevrolet Impala COT - 2011
- [Legacy] NASCAR Cup Chevrolet SS - 2013, formerly known as, [Archive] NASCAR Cup Chevrolet SS
- [Legacy] NASCAR Cup Ford Fusion - 2016, formerly known as, [Archive] Sprint Cup Ford Fusion
- [Legacy] NASCAR Nationwide Chevrolet Impala - 2012, formerly known as, [Archive] Nationwide Chevrolet Impala - 2011
- [Legacy] NASCAR Truck Chevrolet Silverado - 2008, formerly known as, NASCAR Truck Series Chevrolet Silverado - 2013
- [Legacy] NASCAR Xfinity Chevrolet Camaro - 2014, formerly known as, [Archive] XFINITY Chevrolet Camaro
- [Legacy] NASCAR Xfinity Ford Mustang - 2016, formerly known as, [Archive] XFINITY Ford Mustang
- [Legacy] NASCAR Xfinity Toyota Camry - 2015, formerly known as, [Archive] XFINITY Toyota Camry
- [Legacy] Riley MkXX Daytona Prototype - 2008, formerly known as, [Archive] Riley MkXX Daytona Prototype
- [Legacy] V8 Supercar Ford Falcon - 2009, formerly known as, [Archive] V8 Supercar Ford Falcon - 2012
- [Legacy] V8 Supercar Ford FG Falcon - 2014, formerly known as, [Archive] V8 Supercars Ford FG Falcon
- [Legacy] V8 Supercar Holden VF Commodore - 2014, formerly known as, [Archive] V8 Supercars Holden VF Commodore

TRACKS:
- [Legacy] Charlotte Motor Speedway - 2008, formerly known as, Charlotte Motor Speedway - 2016
- [Legacy] Daytona International Speedway - 2008, formerly known as, Daytona International Speedway - 2007
- [Legacy] Lime Rock Park - 2008, formerly known as, [Archive] Lime Rock Park - 2007
- [Legacy] Michigan International Speedway - 2009, formerly known as, Michigan International Speedway - 2014
- [Legacy] Phoenix Raceway - 2008, formerly known as, Phoenix International Raceway - 2008
- [Legacy] Pocono Raceway - 2009, formerly known as, Pocono Raceway - 2011
- [Legacy] Silverstone Circuit - 2008, formerly known as, Silverstone Circuit - 2011
- [Legacy] Texas Motor Speedway - 2009, formerly known as, [Archive] Texas Motor Speedway - 2009

