### PR TITLE
Edit NASCAR Chevrolet Silverado 2015 & 2019

### DIFF
--- a/vehicles.ini
+++ b/vehicles.ini
@@ -54,7 +54,8 @@ stockcars camarozl12018,NASCAR Cup Chevrolet Camaro ZL1,4,9000
 stockcars fordmustang2019,NASCAR Cup Ford Mustang,4,9000
 stockcars toyotacamry,NASCAR Cup Toyota Camry,4,9000
 stockcars fordthunderbird87,NASCAR Ford Thunderbird - 1987,4,7000
-trucks silverado2015,NASCAR Gander Outdoors Chevrolet Silverado,4,8000
+trucks silverado2015,NASCAR Trucks Series Chevrolet Silverado - 2018,4,8000
+trucks silverado2019,NASCAR Gander Outdoors Chevrolet Silverado,4,8000
 trucks fordf150,NASCAR Gander Outdoors Ford F150,4,8000
 trucks tundra2015,NASCAR Gander Outdoors Toyota Tundra,4,8000
 stockcars2 chevy,NASCAR K&N Pro Chevrolet Impala,4,8000


### PR DESCRIPTION
Edit entries to retain current and retired vehicles.