### PR TITLE
Update SCCA Spec Racer Ford

### DIFF
--- a/vehicles.ini
+++ b/vehicles.ini
@@ -83,7 +83,7 @@ rufrt12r awd,Ruf RT 12R AWD,6,7000
 rufrt12r track cspec,Ruf RT 12R C-Spec,6,7800
 rufrt12r rwd,Ruf RT 12R RWD,6,6600
 rufrt12r track,Ruf RT 12R Track,6,8800
-specracer,SCCA Spec Racer Ford,5,5700
+specracer,SCCA Spec Racer Ford,6,6200
 silvercrown,Silver Crown,2,10000
 rt2000,Skip Barber Formula 2000,5,6000
 sprint,Sprint Car,1,10000


### PR DESCRIPTION
Provided information
specracer,SCCA Spec Racer Ford,6,6200

Additional notes
This update changes the number of gears from 5 to 6.