### PR TITLE
Add Aston Martin Vantage GT4

### DIFF
--- a/vehicles.ini
+++ b/vehicles.ini
@@ -1,5 +1,6 @@
 ;name,alias,gears,rpm (will be sorted alphabetically by alias)
 astonmartin dbr9,Aston Martin DBR9 GT1,6,7000
+amvantagegt4,Aston Martin Vantage GT4,6,7000
 audi90gto,Audi 90 GTO,5,7600
 audir18,Audi R18,6,4200
 audir8gt3,Audi R8 LMS,6,7000


### PR DESCRIPTION
#63 

Note: the iRacing API value for `SessionData.DriverInfo.DriverCarSLShiftRPM` for this car is 7050... but when I tried this I could hear it hitting the limiter (probably just because of the delay between me hearing the beep and pulling my shifter). So I found 7000 better.