### PR TITLE
Add NASCAR Cup Next Gen Toyota Camry

### DIFF
--- a/vehicles.ini
+++ b/vehicles.ini
@@ -73,7 +73,7 @@ stockcars toyotacamry,NASCAR Cup Toyota Camry,4,9000
 stockcars fordthunderbird87,NASCAR Ford Thunderbird - 1987,4,7000
 stockcars chevycamarozl12022,NASCAR Cup Next Gen Chevrolet Camaro ZL1,5,9000
 stockcars fordmustang2022,NASCAR Cup Next Gen Ford Mustang,5,9000
-stockcars chevycamarozl12022,NASCAR Cup Next Gen Chevrolet Camaro ZL1,5,9000
+stockcars toyotacamry2022,NASCAR Cup Next Gen Toyota Camry,5,9000
 trucks silverado2015,NASCAR Trucks Series Chevrolet Silverado - 2018,4,8000
 trucks silverado2019,NASCAR Gander Outdoors Chevrolet Silverado,4,8000
 trucks fordf150,NASCAR Gander Outdoors Ford F150,4,8000


### PR DESCRIPTION
With correct entry of;
stockcars toyotacamry2022,NASCAR Cup Next Gen Toyota Camry,5,9000