### PR TITLE
Edit Global Mazda MX-5 Cup shift point to 7200 rpm

### DIFF
--- a/vehicles.ini
+++ b/vehicles.ini
@@ -40,7 +40,7 @@ fr500s,Ford Mustang FR500S,6,6600
 formularenault20,Formula Renault 2.0,7,7200
 formularenault35,Formula Renault 3.5,6,9000
 formulavee,Formula Vee,4,6700
-mx5 mx52016,Global Mazda MX-5 Cup,6,6400
+mx5 mx52016,Global Mazda MX-5 Cup,6,7200
 hondacivictyper,Honda Civic Type R,6,7000
 hpdarx01c,HPD ARX-01c,6,9500
 hyundaielantracn7,Hyundai Elantra N TC,6,7000


### PR DESCRIPTION
Because 6400rpm is way to low. 7200 is the exact moment the red light comes on in game.