### PR TITLE
Add BMW M2 G87

### DIFF
--- a/vehicles.ini
+++ b/vehicles.ini
@@ -14,6 +14,7 @@ audir8lmsevo2gt3,Audi R8 LMS EVO II GT3,6,8200
 audirs3lms,Audi RS 3 LMS,6,6600
 bmwlmdh,BMW M Hybrid V8,7,7750
 bmwm2csr,BMW M2 CS Racing,7,7000
+bmwm2g87,BMW M2 G87,7,6700
 bmwm8gte,BMW M8 GTE,6,6800
 bmwm4gt3,BMW M4 GT3,6,6700
 bmwm4gt4,BMW M4 F82 GT4 - 2018,5,7100


### PR DESCRIPTION
Adds vehicles.ini entry for the BMW M2 G87 (7 gears, 6700 rpm).